### PR TITLE
Fix project warning related to the keyWindow on iOS >= 13

### DIFF
--- a/LeakInspectorAlertProvider.swift
+++ b/LeakInspectorAlertProvider.swift
@@ -29,7 +29,14 @@ extension UIAlertController {
     }
 
     func present(animated: Bool, completion: (() -> Void)?) {
-        if let rootVC = UIApplication.shared.keyWindow?.rootViewController {
+        let keyWindow: UIWindow? = {
+            if #available(iOS 13, *) {
+                return UIApplication.shared.windows.first { $0.isKeyWindow }
+            } else {
+                return UIApplication.shared.keyWindow
+            }
+        }()
+        if let rootVC = keyWindow?.rootViewController {
             present(from: rootVC, animated: animated, completion: completion)
         }
     }


### PR DESCRIPTION
This PR follows the same approach as another @twobitlabs library ([twobitlabs/AnalyticsKit](https://github.com/twobitlabs/AnalyticsKit/commit/05987683c9b14feae588ee0cb9d9a79168b6aa70)) when it comes to resolving this build warning when setting the minimum build target to iOS 13 (or later).

The `present` func could result in a no-op still, but it shouldn't be any more likely than the prior implementation.